### PR TITLE
Stabilize chain start

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,11 +81,8 @@ jobs:
           paths:
             - ~/.cache/yarn
       - run:
-          name: Wait for blockchain and REST server to be ready (started in background)
-          command: timeout 60 bash -c "until curl -s http://localhost:1317/node_info > /dev/null; do sleep 1; done"
-      - run:
-          name: Deploy ERC20 contract
-          command: ./scripts/cosm/deploy_erc20.js
+          name: Initialize blockchain (deploy contracts and friends)
+          command: ./scripts/cosm/init.sh
       - run:
           environment:
             COSMOS_ENABLED: 1

--- a/packages/sdk/src/restclient.spec.ts
+++ b/packages/sdk/src/restclient.spec.ts
@@ -236,7 +236,7 @@ describe("RestClient", () => {
       });
     });
 
-    // this is failing for me on first run (faucet has not signed anything)
+    // This fails in the first test run if you forget to run `./scripts/cosm/init.sh`
     it("has correct pubkey for faucet", async () => {
       pendingWithoutCosmos();
       const client = new RestClient(httpUrl);

--- a/scripts/cosm/README.md
+++ b/scripts/cosm/README.md
@@ -5,7 +5,7 @@
 Run the following:
 
 ```
-./start.sh
+./start.sh && ./init.sh
 ```
 
 ## CLI

--- a/scripts/cosm/init.sh
+++ b/scripts/cosm/init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck > /dev/null && shellcheck "$0"
+
+echo "Waiting for blockchain and REST server to be available ..."
+timeout 60 bash -c "until curl -s http://localhost:1317/node_info > /dev/null; do sleep 0.5; done"
+# The chain is unreliable in the first second of its existence (https://gist.github.com/webmaster128/8175692d4af5e6c572fddda7a9ef437c)
+sleep 1
+echo "Okay, thank you for your patience."
+
+SCRIPT_DIR="$(realpath "$(dirname "$0")")"
+"$SCRIPT_DIR/deploy_erc20.js"


### PR DESCRIPTION
This fixes the issues we had before. Deploying contracts within the first 1 or 2 seconds is unstable. I pasted the erros in the gist.