### PR TITLE
Migrate rule no-unnecessary-type-assertion from tslint to eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
     "@typescript-eslint/no-use-before-define": "warn",
     "@typescript-eslint/prefer-readonly": "warn",
   },

--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,7 @@
     "no-implicit-dependencies": false,
     "no-parameter-reassignment": false,
     "no-unnecessary-class": [true, "allow-static-only"],
-    "no-unnecessary-type-assertion": true,
+    "no-unnecessary-type-assertion": false,
     "no-var-keyword": true,
     "object-literal-shorthand": [true, "never"],
     "object-literal-sort-keys": false,


### PR DESCRIPTION
The eslint implementation seems to be better. And tslint is deprecated.