### PR TITLE
Test block responses at RestClient level

### DIFF
--- a/packages/sdk/src/cosmwasmclient.spec.ts
+++ b/packages/sdk/src/cosmwasmclient.spec.ts
@@ -9,7 +9,7 @@ import { findAttribute } from "./logs";
 import { Secp256k1Pen } from "./pen";
 import { RestClient } from "./restclient";
 import cosmoshub from "./testdata/cosmoshub.json";
-import { getRandomizedHackatom, makeRandomAddress } from "./testutils.spec";
+import { getRandomizedHackatom, makeRandomAddress, tendermintIdMatcher } from "./testutils.spec";
 import { Coin, CosmosSdkTx, MsgSend, StdFee } from "./types";
 
 const { fromAscii, fromUtf8, toAscii } = Encoding;
@@ -82,7 +82,7 @@ describe("CosmWasmClient", () => {
       const response = await client.getBlock();
 
       // id
-      expect(response.block_id.hash).toMatch(/^[0-9A-F]{64}$/);
+      expect(response.block_id.hash).toMatch(tendermintIdMatcher);
 
       // header
       expect(parseInt(response.block.header.height, 10)).toBeGreaterThanOrEqual(1);
@@ -103,7 +103,7 @@ describe("CosmWasmClient", () => {
       const response = await client.getBlock(height - 1);
 
       // id
-      expect(response.block_id.hash).toMatch(/^[0-9A-F]{64}$/);
+      expect(response.block_id.hash).toMatch(tendermintIdMatcher);
 
       // header
       expect(response.block.header.height).toEqual(`${height - 1}`);

--- a/packages/sdk/src/restclient.spec.ts
+++ b/packages/sdk/src/restclient.spec.ts
@@ -10,7 +10,13 @@ import { Pen, Secp256k1Pen } from "./pen";
 import { encodeBech32Pubkey } from "./pubkey";
 import { PostTxsResponse, RestClient } from "./restclient";
 import cosmoshub from "./testdata/cosmoshub.json";
-import { getRandomizedHackatom, makeRandomAddress, tendermintIdMatcher } from "./testutils.spec";
+import {
+  getRandomizedHackatom,
+  makeRandomAddress,
+  tendermintAddressMatcher,
+  tendermintIdMatcher,
+  tendermintOptionalIdMatcher,
+} from "./testutils.spec";
 import {
   Coin,
   Msg,
@@ -190,12 +196,23 @@ describe("RestClient", () => {
       expect(response.block_id.hash).toMatch(tendermintIdMatcher);
 
       // header
+      expect(response.block.header.version).toEqual({ block: "10", app: "0" });
       expect(parseInt(response.block.header.height, 10)).toBeGreaterThanOrEqual(1);
       expect(response.block.header.chain_id).toEqual(defaultNetworkId);
       expect(new ReadonlyDate(response.block.header.time).getTime()).toBeLessThan(ReadonlyDate.now());
       expect(new ReadonlyDate(response.block.header.time).getTime()).toBeGreaterThanOrEqual(
         ReadonlyDate.now() - 5_000,
       );
+      expect(response.block.header.last_commit_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.last_block_id.hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.data_hash).toMatch(tendermintOptionalIdMatcher);
+      expect(response.block.header.validators_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.next_validators_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.consensus_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.app_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.last_results_hash).toMatch(tendermintOptionalIdMatcher);
+      expect(response.block.header.evidence_hash).toMatch(tendermintOptionalIdMatcher);
+      expect(response.block.header.proposer_address).toMatch(tendermintAddressMatcher);
 
       // data
       expect(response.block.data.txs === null || Array.isArray(response.block.data.txs)).toEqual(true);
@@ -213,12 +230,23 @@ describe("RestClient", () => {
       expect(response.block_id.hash).toMatch(tendermintIdMatcher);
 
       // header
+      expect(response.block.header.version).toEqual({ block: "10", app: "0" });
       expect(response.block.header.height).toEqual(`${height - 1}`);
       expect(response.block.header.chain_id).toEqual(defaultNetworkId);
       expect(new ReadonlyDate(response.block.header.time).getTime()).toBeLessThan(ReadonlyDate.now());
       expect(new ReadonlyDate(response.block.header.time).getTime()).toBeGreaterThanOrEqual(
         ReadonlyDate.now() - 5_000,
       );
+      expect(response.block.header.last_commit_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.last_block_id.hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.data_hash).toMatch(tendermintOptionalIdMatcher);
+      expect(response.block.header.validators_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.next_validators_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.consensus_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.app_hash).toMatch(tendermintIdMatcher);
+      expect(response.block.header.last_results_hash).toMatch(tendermintOptionalIdMatcher);
+      expect(response.block.header.evidence_hash).toMatch(tendermintOptionalIdMatcher);
+      expect(response.block.header.proposer_address).toMatch(tendermintAddressMatcher);
 
       // data
       expect(response.block.data.txs === null || Array.isArray(response.block.data.txs)).toEqual(true);

--- a/packages/sdk/src/restclient.ts
+++ b/packages/sdk/src/restclient.ts
@@ -22,28 +22,37 @@ interface NodeInfoResponse {
   readonly node_info: NodeInfo;
 }
 
+export interface BlockId {
+  readonly hash: string;
+  // TODO: here we also have this
+  // parts: {
+  //   total: '1',
+  //   hash: '7AF200C78FBF9236944E1AB270F4045CD60972B7C265E3A9DA42973397572931'
+  // }
+}
+
 export interface BlockHeader {
+  readonly version: {
+    readonly block: string;
+    readonly app: string;
+  };
   readonly height: string;
   readonly chain_id: string;
   /** An RFC 3339 time string like e.g. '2020-02-15T10:39:10.4696305Z' */
   readonly time: string;
-  // TODO: add all of those
-  // header: {
-  //   version: [Object],
-  //   chain_id: 'testing',
-  //   height: '41121',
-  //   time: '2020-02-15T10:39:10.4696305Z',
-  //   last_block_id: [Object],
-  //   last_commit_hash: '9C68EDA02AEB5F6A76AA03F7F7E6834D73424A8906FE5A79B04D310C2DB5EFFC',
-  //   data_hash: '',
-  //   validators_hash: '4412A0B61BAC7D1EEDA531F3FBA8E90BBB3DDF6CCA85B28CA1D8300818F0E7EA',
-  //   next_validators_hash: '4412A0B61BAC7D1EEDA531F3FBA8E90BBB3DDF6CCA85B28CA1D8300818F0E7EA',
-  //   consensus_hash: '048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F',
-  //   app_hash: 'DD58B3B4AB1031ECB0CED45C017B57EE2E6E22FA7F0ECA355268CC205C6A1A64',
-  //   last_results_hash: '',
-  //   evidence_hash: '',
-  //   proposer_address: '3FBF50B72FE062495F150AEB78D1981E7DAEBE60'
-  // },
+  readonly last_commit_hash: string;
+  readonly last_block_id: BlockId;
+  /** Can be empty */
+  readonly data_hash: string;
+  readonly validators_hash: string;
+  readonly next_validators_hash: string;
+  readonly consensus_hash: string;
+  readonly app_hash: string;
+  /** Can be empty */
+  readonly last_results_hash: string;
+  /** Can be empty */
+  readonly evidence_hash: string;
+  readonly proposer_address: string;
 }
 
 export interface Block {
@@ -55,14 +64,7 @@ export interface Block {
 }
 
 export interface BlockResponse {
-  readonly block_id: {
-    readonly hash: string;
-    // TODO: here we also have this
-    // parts: {
-    //   total: '1',
-    //   hash: '7AF200C78FBF9236944E1AB270F4045CD60972B7C265E3A9DA42973397572931'
-    // }
-  };
+  readonly block_id: BlockId;
   readonly block: Block;
 }
 

--- a/packages/sdk/src/testutils.spec.ts
+++ b/packages/sdk/src/testutils.spec.ts
@@ -55,6 +55,8 @@ export function makeRandomAddress(): string {
 }
 
 export const tendermintIdMatcher = /^[0-9A-F]{64}$/;
+export const tendermintOptionalIdMatcher = /^([0-9A-F]{64}|)$/;
+export const tendermintAddressMatcher = /^[0-9A-F]{40}$/;
 
 describe("leb128", () => {
   describe("leb128Encode", () => {

--- a/packages/sdk/src/testutils.spec.ts
+++ b/packages/sdk/src/testutils.spec.ts
@@ -54,6 +54,8 @@ export function makeRandomAddress(): string {
   return Bech32.encode("cosmos", Random.getBytes(20));
 }
 
+export const tendermintIdMatcher = /^[0-9A-F]{64}$/;
+
 describe("leb128", () => {
   describe("leb128Encode", () => {
     it("works for single byte values", () => {

--- a/packages/sdk/types/restclient.d.ts
+++ b/packages/sdk/types/restclient.d.ts
@@ -5,11 +5,31 @@ interface NodeInfo {
 interface NodeInfoResponse {
   readonly node_info: NodeInfo;
 }
+export interface BlockId {
+  readonly hash: string;
+}
 export interface BlockHeader {
+  readonly version: {
+    readonly block: string;
+    readonly app: string;
+  };
   readonly height: string;
   readonly chain_id: string;
   /** An RFC 3339 time string like e.g. '2020-02-15T10:39:10.4696305Z' */
   readonly time: string;
+  readonly last_commit_hash: string;
+  readonly last_block_id: BlockId;
+  /** Can be empty */
+  readonly data_hash: string;
+  readonly validators_hash: string;
+  readonly next_validators_hash: string;
+  readonly consensus_hash: string;
+  readonly app_hash: string;
+  /** Can be empty */
+  readonly last_results_hash: string;
+  /** Can be empty */
+  readonly evidence_hash: string;
+  readonly proposer_address: string;
 }
 export interface Block {
   readonly header: BlockHeader;
@@ -19,9 +39,7 @@ export interface Block {
   };
 }
 export interface BlockResponse {
-  readonly block_id: {
-    readonly hash: string;
-  };
+  readonly block_id: BlockId;
   readonly block: Block;
 }
 interface AuthAccountsResponse {


### PR DESCRIPTION
Testing this functionality at CosmWasmClient level does not make much sense, since it does not test the client but the REST API. This duplicates those tests for the lower layer and adds the mission fields.