### PR TITLE
Add getAccount to CosmWasmClient

### DIFF
--- a/packages/bcp/src/address.ts
+++ b/packages/bcp/src/address.ts
@@ -5,9 +5,7 @@ import { Encoding } from "@iov/encoding";
 
 const { fromBase64, toBase64 } = Encoding;
 
-export function decodeCosmosPubkey(
-  encodedPubkey: string,
-): { readonly algo: Algorithm; readonly data: PubkeyBytes } {
+export function decodeCosmosPubkey(encodedPubkey: string): PubkeyBundle {
   const sdkPubKey = decodeBech32Pubkey(encodedPubkey);
   switch (sdkPubKey.type) {
     case types.pubkeyType.secp256k1:

--- a/packages/bcp/src/cosmwasmconnection.ts
+++ b/packages/bcp/src/cosmwasmconnection.ts
@@ -3,7 +3,6 @@ import {
   CosmosAddressBech32Prefix,
   CosmWasmClient,
   findSequenceForSignedTx,
-  RestClient,
   TxsResponse,
   types,
 } from "@cosmwasm/sdk";
@@ -74,10 +73,9 @@ export class CosmWasmConnection implements BlockchainConnection {
     addressPrefix: CosmosAddressBech32Prefix,
     tokens: TokenConfiguration,
   ): Promise<CosmWasmConnection> {
-    const restClient = new RestClient(url);
     const cosmWasmClient = CosmWasmClient.makeReadOnly(url);
     const chainData = await this.initialize(cosmWasmClient);
-    return new CosmWasmConnection(restClient, cosmWasmClient, chainData, addressPrefix, tokens);
+    return new CosmWasmConnection(cosmWasmClient, chainData, addressPrefix, tokens);
   }
 
   private static async initialize(cosmWasmClient: CosmWasmClient): Promise<ChainId> {
@@ -88,8 +86,6 @@ export class CosmWasmConnection implements BlockchainConnection {
   public readonly chainId: ChainId;
   public readonly codec: TxCodec;
 
-  /** @deprecated everything we use from RestClient should be available in CosmWasmClient */
-  private readonly restClient: RestClient;
   private readonly cosmWasmClient: CosmWasmClient;
   private readonly addressPrefix: CosmosAddressBech32Prefix;
   private readonly bankTokens: readonly BankToken[];
@@ -100,14 +96,11 @@ export class CosmWasmConnection implements BlockchainConnection {
   private readonly supportedTokens: readonly Token[];
 
   private constructor(
-    restClient: RestClient,
     cosmWasmClient: CosmWasmClient,
     chainId: ChainId,
     addressPrefix: CosmosAddressBech32Prefix,
     tokens: TokenConfiguration,
   ) {
-    // tslint:disable-next-line: deprecation
-    this.restClient = restClient;
     this.cosmWasmClient = cosmWasmClient;
     this.chainId = chainId;
     this.codec = new CosmWasmCodec(addressPrefix, tokens.bankTokens, tokens.erc20Tokens);

--- a/packages/bcp/types/address.d.ts
+++ b/packages/bcp/types/address.d.ts
@@ -1,9 +1,4 @@
 import { CosmosAddressBech32Prefix } from "@cosmwasm/sdk";
-import { Address, Algorithm, PubkeyBundle, PubkeyBytes } from "@iov/bcp";
-export declare function decodeCosmosPubkey(
-  encodedPubkey: string,
-): {
-  readonly algo: Algorithm;
-  readonly data: PubkeyBytes;
-};
+import { Address, PubkeyBundle } from "@iov/bcp";
+export declare function decodeCosmosPubkey(encodedPubkey: string): PubkeyBundle;
 export declare function pubkeyToAddress(pubkey: PubkeyBundle, prefix: CosmosAddressBech32Prefix): Address;

--- a/packages/bcp/types/cosmwasmconnection.d.ts
+++ b/packages/bcp/types/cosmwasmconnection.d.ts
@@ -47,8 +47,6 @@ export declare class CosmWasmConnection implements BlockchainConnection {
   private static initialize;
   readonly chainId: ChainId;
   readonly codec: TxCodec;
-  /** @deprecated everything we use from RestClient should be available in CosmWasmClient */
-  private readonly restClient;
   private readonly cosmWasmClient;
   private readonly addressPrefix;
   private readonly bankTokens;

--- a/packages/sdk/src/cosmwasmclient.spec.ts
+++ b/packages/sdk/src/cosmwasmclient.spec.ts
@@ -74,14 +74,14 @@ describe("CosmWasmClient", () => {
       });
     });
 
-    it("returns zeros for missing accounts", async () => {
+    it("throws for missing accounts", async () => {
       pendingWithoutCosmos();
       const client = CosmWasmClient.makeReadOnly(httpUrl);
       const missing = makeRandomAddress();
-      expect(await client.getNonce(missing)).toEqual({
-        accountNumber: 0,
-        sequence: 0,
-      });
+      await client.getNonce(missing).then(
+        () => fail("this must not succeed"),
+        error => expect(error).toMatch(/account does not exist on chain/i),
+      );
     });
   });
 

--- a/packages/sdk/src/cosmwasmclient.spec.ts
+++ b/packages/sdk/src/cosmwasmclient.spec.ts
@@ -74,7 +74,15 @@ describe("CosmWasmClient", () => {
       });
     });
 
-
+    it("returns zeros for missing accounts", async () => {
+      pendingWithoutCosmos();
+      const client = CosmWasmClient.makeReadOnly(httpUrl);
+      const missing = makeRandomAddress();
+      expect(await client.getNonce(missing)).toEqual({
+        accountNumber: 0,
+        sequence: 0,
+      });
+    });
   });
 
   describe("getAccount", () => {
@@ -87,10 +95,17 @@ describe("CosmWasmClient", () => {
         sequence: 0,
         public_key: "",
         coins: [
-          {denom: 'ucosm', amount: '1000000000'},
-          {denom: 'ustake', amount: '1000000000'},
+          { denom: "ucosm", amount: "1000000000" },
+          { denom: "ustake", amount: "1000000000" },
         ],
       });
+    });
+
+    it("returns undefined for missing accounts", async () => {
+      pendingWithoutCosmos();
+      const client = CosmWasmClient.makeReadOnly(httpUrl);
+      const missing = makeRandomAddress();
+      expect(await client.getAccount(missing)).toBeUndefined();
     });
   });
 

--- a/packages/sdk/src/cosmwasmclient.spec.ts
+++ b/packages/sdk/src/cosmwasmclient.spec.ts
@@ -73,6 +73,25 @@ describe("CosmWasmClient", () => {
         sequence: 0,
       });
     });
+
+
+  });
+
+  describe("getAccount", () => {
+    it("works", async () => {
+      pendingWithoutCosmos();
+      const client = CosmWasmClient.makeReadOnly(httpUrl);
+      expect(await client.getAccount(unusedAccount.address)).toEqual({
+        address: unusedAccount.address,
+        account_number: 5,
+        sequence: 0,
+        public_key: "",
+        coins: [
+          {denom: 'ucosm', amount: '1000000000'},
+          {denom: 'ustake', amount: '1000000000'},
+        ],
+      });
+    });
   });
 
   describe("getBlock", () => {

--- a/packages/sdk/src/cosmwasmclient.ts
+++ b/packages/sdk/src/cosmwasmclient.ts
@@ -6,13 +6,13 @@ import { findAttribute, Log, parseLogs } from "./logs";
 import { BlockResponse, RestClient, TxsResponse } from "./restclient";
 import {
   Coin,
+  CosmosSdkAccount,
   CosmosSdkTx,
   MsgExecuteContract,
   MsgInstantiateContract,
   MsgStoreCode,
   StdFee,
   StdSignature,
-  CosmosSdkAccount,
 } from "./types";
 
 const defaultUploadFee: StdFee = {

--- a/packages/sdk/src/cosmwasmclient.ts
+++ b/packages/sdk/src/cosmwasmclient.ts
@@ -12,6 +12,7 @@ import {
   MsgStoreCode,
   StdFee,
   StdSignature,
+  CosmosSdkAccount,
 } from "./types";
 
 const defaultUploadFee: StdFee = {
@@ -150,11 +151,16 @@ export class CosmWasmClient {
    * @param address returns data for this address. When unset, the client's sender adddress is used.
    */
   public async getNonce(address?: string): Promise<GetNonceResult> {
-    const account = (await this.restClient.authAccounts(address || this.senderAddress)).result.value;
+    const account = await this.getAccount(address);
     return {
       accountNumber: account.account_number,
       sequence: account.sequence,
     };
+  }
+
+  public async getAccount(address?: string): Promise<CosmosSdkAccount> {
+    const account = await this.restClient.authAccounts(address || this.senderAddress);
+    return account.result.value;
   }
 
   /**

--- a/packages/sdk/src/cosmwasmclient.ts
+++ b/packages/sdk/src/cosmwasmclient.ts
@@ -148,13 +148,20 @@ export class CosmWasmClient {
   /**
    * Returns account number and sequence.
    *
+   * Throws if the account does not exist on chain.
+   *
    * @param address returns data for this address. When unset, the client's sender adddress is used.
    */
   public async getNonce(address?: string): Promise<GetNonceResult> {
     const account = await this.getAccount(address);
+    if (!account) {
+      throw new Error(
+        "Account does not exist on chain. Send some tokens there before trying to query nonces.",
+      );
+    }
     return {
-      accountNumber: account ? account.account_number : 0,
-      sequence: account ? account.sequence : 0,
+      accountNumber: account.account_number,
+      sequence: account.sequence,
     };
   }
 

--- a/packages/sdk/src/cosmwasmclient.ts
+++ b/packages/sdk/src/cosmwasmclient.ts
@@ -153,14 +153,15 @@ export class CosmWasmClient {
   public async getNonce(address?: string): Promise<GetNonceResult> {
     const account = await this.getAccount(address);
     return {
-      accountNumber: account.account_number,
-      sequence: account.sequence,
+      accountNumber: account ? account.account_number : 0,
+      sequence: account ? account.sequence : 0,
     };
   }
 
-  public async getAccount(address?: string): Promise<CosmosSdkAccount> {
+  public async getAccount(address?: string): Promise<CosmosSdkAccount | undefined> {
     const account = await this.restClient.authAccounts(address || this.senderAddress);
-    return account.result.value;
+    const value = account.result.value;
+    return value.address === "" ? undefined : value;
   }
 
   /**

--- a/packages/sdk/src/restclient.spec.ts
+++ b/packages/sdk/src/restclient.spec.ts
@@ -290,6 +290,18 @@ describe("RestClient", () => {
         }),
       );
     });
+
+    // This property is used by CosmWasmClient.getAccount
+    it("returns empty address for non-existent account", async () => {
+      pendingWithoutCosmos();
+      const client = new RestClient(httpUrl);
+      const nonExistentAccount = makeRandomAddress();
+      const { result } = await client.authAccounts(nonExistentAccount);
+      expect(result).toEqual({
+        type: "cosmos-sdk/Account",
+        value: jasmine.objectContaining({ address: "" }),
+      });
+    });
   });
 
   describe("encodeTx", () => {

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -1,6 +1,6 @@
 import { Log } from "./logs";
 import { BlockResponse, TxsResponse } from "./restclient";
-import { Coin, CosmosSdkTx, StdSignature } from "./types";
+import { Coin, CosmosSdkTx, StdSignature, CosmosSdkAccount } from "./types";
 export interface SigningCallback {
   (signBytes: Uint8Array): Promise<StdSignature>;
 }
@@ -46,6 +46,7 @@ export declare class CosmWasmClient {
    * @param address returns data for this address. When unset, the client's sender adddress is used.
    */
   getNonce(address?: string): Promise<GetNonceResult>;
+  getAccount(address?: string): Promise<CosmosSdkAccount>;
   /**
    * Gets block header and meta
    *

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -46,7 +46,7 @@ export declare class CosmWasmClient {
    * @param address returns data for this address. When unset, the client's sender adddress is used.
    */
   getNonce(address?: string): Promise<GetNonceResult>;
-  getAccount(address?: string): Promise<CosmosSdkAccount>;
+  getAccount(address?: string): Promise<CosmosSdkAccount | undefined>;
   /**
    * Gets block header and meta
    *

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -1,6 +1,6 @@
 import { Log } from "./logs";
 import { BlockResponse, TxsResponse } from "./restclient";
-import { Coin, CosmosSdkTx, StdSignature, CosmosSdkAccount } from "./types";
+import { Coin, CosmosSdkAccount, CosmosSdkTx, StdSignature } from "./types";
 export interface SigningCallback {
   (signBytes: Uint8Array): Promise<StdSignature>;
 }
@@ -42,6 +42,8 @@ export declare class CosmWasmClient {
   getIdentifier(tx: CosmosSdkTx): Promise<string>;
   /**
    * Returns account number and sequence.
+   *
+   * Throws if the account does not exist on chain.
    *
    * @param address returns data for this address. When unset, the client's sender adddress is used.
    */


### PR DESCRIPTION
This is only available on the RestClient now, which was a bit annoying when writing the frontend app. Expose it in CosmWasmClient with a cleaner return value (undefined for no such account)