### PR TITLE
Expose sendToken() on CosmWasmClient

### DIFF
--- a/packages/sdk/src/cosmwasmclient.spec.ts
+++ b/packages/sdk/src/cosmwasmclient.spec.ts
@@ -222,50 +222,23 @@ describe("CosmWasmClient", () => {
     beforeAll(async () => {
       if (cosmosEnabled()) {
         const pen = await Secp256k1Pen.fromMnemonic(faucet.mnemonic);
-        const client = CosmWasmClient.makeReadOnly(httpUrl);
+        const client = CosmWasmClient.makeWritable(httpUrl, faucet.address, signBytes => pen.sign(signBytes));
 
         const memo = "My first contract on chain";
-        const sendMsg: MsgSend = {
-          type: "cosmos-sdk/MsgSend",
-          value: {
-            from_address: faucet.address,
-            to_address: makeRandomAddress(),
-            amount: [
-              {
-                denom: "ucosm",
-                amount: "1234567",
-              },
-            ],
+        const recipient = makeRandomAddress();
+        const transferAmount = [
+          {
+            denom: "ucosm",
+            amount: "1234567",
           },
-        };
+        ];
+        const result = await client.sendToken(recipient, transferAmount, memo);
 
-        const fee: StdFee = {
-          amount: [
-            {
-              amount: "5000",
-              denom: "ucosm",
-            },
-          ],
-          gas: "890000",
-        };
-
-        const chainId = await client.chainId();
-        const { accountNumber, sequence } = await client.getNonce(faucet.address);
-        const signBytes = makeSignBytes([sendMsg], fee, chainId, memo, accountNumber, sequence);
-        const signature = await pen.sign(signBytes);
-        const signedTx = {
-          msg: [sendMsg],
-          fee: fee,
-          memo: memo,
-          signatures: [signature],
-        };
-
-        const result = await client.postTx(marshalTx(signedTx));
         await sleep(50); // wait until tx is indexed
         const txDetails = await new RestClient(httpUrl).txsById(result.transactionHash);
         posted = {
-          sender: sendMsg.value.from_address,
-          recipient: sendMsg.value.to_address,
+          sender: faucet.address,
+          recipient: recipient,
           hash: result.transactionHash,
           height: Number.parseInt(txDetails.height, 10),
           tx: txDetails.tx,

--- a/packages/sdk/src/cosmwasmclient.spec.ts
+++ b/packages/sdk/src/cosmwasmclient.spec.ts
@@ -232,7 +232,7 @@ describe("CosmWasmClient", () => {
             amount: "1234567",
           },
         ];
-        const result = await client.sendToken(recipient, transferAmount, memo);
+        const result = await client.sendTokens(recipient, transferAmount, memo);
 
         await sleep(50); // wait until tx is indexed
         const txDetails = await new RestClient(httpUrl).txsById(result.transactionHash);
@@ -419,7 +419,7 @@ describe("CosmWasmClient", () => {
     });
   });
 
-  describe("sendToken", () => {
+  describe("sendTokens", () => {
     it("works", async () => {
       pendingWithoutCosmos();
       const pen = await Secp256k1Pen.fromMnemonic(faucet.mnemonic);
@@ -439,7 +439,7 @@ describe("CosmWasmClient", () => {
       expect(before).toBeUndefined();
 
       // send
-      const result = await client.sendToken(beneficiaryAddress, transferAmount, "for dinner");
+      const result = await client.sendTokens(beneficiaryAddress, transferAmount, "for dinner");
       const [firstLog] = result.logs;
       expect(firstLog).toBeTruthy();
 

--- a/packages/sdk/src/cosmwasmclient.spec.ts
+++ b/packages/sdk/src/cosmwasmclient.spec.ts
@@ -224,7 +224,6 @@ describe("CosmWasmClient", () => {
         const pen = await Secp256k1Pen.fromMnemonic(faucet.mnemonic);
         const client = CosmWasmClient.makeWritable(httpUrl, faucet.address, signBytes => pen.sign(signBytes));
 
-        const memo = "My first contract on chain";
         const recipient = makeRandomAddress();
         const transferAmount = [
           {
@@ -232,7 +231,7 @@ describe("CosmWasmClient", () => {
             amount: "1234567",
           },
         ];
-        const result = await client.sendTokens(recipient, transferAmount, memo);
+        const result = await client.sendTokens(recipient, transferAmount);
 
         await sleep(50); // wait until tx is indexed
         const txDetails = await new RestClient(httpUrl).txsById(result.transactionHash);

--- a/packages/sdk/src/cosmwasmclient.spec.ts
+++ b/packages/sdk/src/cosmwasmclient.spec.ts
@@ -446,6 +446,37 @@ describe("CosmWasmClient", () => {
     });
   });
 
+  describe("sendToken", () => {
+    it("works", async () => {
+      pendingWithoutCosmos();
+      const pen = await Secp256k1Pen.fromMnemonic(faucet.mnemonic);
+      const client = CosmWasmClient.makeWritable(httpUrl, faucet.address, signBytes => pen.sign(signBytes));
+
+      // instantiate
+      const transferAmount: readonly Coin[] = [
+        {
+          amount: "7890",
+          denom: "ucosm",
+        },
+      ];
+      const beneficiaryAddress = makeRandomAddress();
+
+      // no tokens here
+      const before = await client.getAccount(beneficiaryAddress);
+      expect(before).toBeUndefined();
+
+      // send
+      const result = await client.sendToken(beneficiaryAddress, transferAmount, "for dinner");
+      const [firstLog] = result.logs;
+      expect(firstLog).toBeTruthy();
+
+      // got tokens
+      const after = await client.getAccount(beneficiaryAddress);
+      assert(after);
+      expect(after.coins).toEqual(transferAmount);
+    });
+  });
+
   describe("queryContractRaw", () => {
     const configKey = toAscii("config");
     const otherKey = toAscii("this_does_not_exist");

--- a/packages/sdk/src/cosmwasmclient.ts
+++ b/packages/sdk/src/cosmwasmclient.ts
@@ -334,7 +334,7 @@ export class CosmWasmClient {
     recipientAddress: string,
     transferAmount: readonly Coin[],
     memo = "",
-  ): Promise<ExecuteResult> {
+  ): Promise<PostTxResult> {
     const sendMsg: MsgSend = {
       type: "cosmos-sdk/MsgSend",
       value: {
@@ -357,10 +357,7 @@ export class CosmWasmClient {
       signatures: [signature],
     };
 
-    const result = await this.postTx(marshalTx(signedTx));
-    return {
-      logs: result.logs,
-    };
+    return this.postTx(marshalTx(signedTx));
   }
 
   /**

--- a/packages/sdk/src/cosmwasmclient.ts
+++ b/packages/sdk/src/cosmwasmclient.ts
@@ -23,25 +23,25 @@ export interface FeeTable {
   readonly send: StdFee;
 }
 
-const feeAmount = (amount: number, denom: string): readonly Coin[] => [
-  { amount: amount.toString(), denom: denom },
-];
+function singleAmount(amount: number, denom: string): readonly Coin[] {
+  return [{ amount: amount.toString(), denom: denom }];
+}
 
 const defaultFeeTable: FeeTable = {
   upload: {
-    amount: feeAmount(25000, "ucosm"),
+    amount: singleAmount(25000, "ucosm"),
     gas: "1000000", // one million
   },
   init: {
-    amount: feeAmount(12500, "ucosm"),
+    amount: singleAmount(12500, "ucosm"),
     gas: "500000", // 500k
   },
   exec: {
-    amount: feeAmount(5000, "ucosm"),
+    amount: singleAmount(5000, "ucosm"),
     gas: "200000", // 200k
   },
   send: {
-    amount: feeAmount(2000, "ucosm"),
+    amount: singleAmount(2000, "ucosm"),
     gas: "80000", // 80k
   },
 };

--- a/packages/sdk/src/cosmwasmclient.ts
+++ b/packages/sdk/src/cosmwasmclient.ts
@@ -330,7 +330,7 @@ export class CosmWasmClient {
     };
   }
 
-  public async sendToken(
+  public async sendTokens(
     recipientAddress: string,
     transferAmount: readonly Coin[],
     memo = "",

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -1,6 +1,12 @@
 import { Log } from "./logs";
 import { BlockResponse, TxsResponse } from "./restclient";
-import { Coin, CosmosSdkAccount, CosmosSdkTx, StdSignature } from "./types";
+import { Coin, CosmosSdkAccount, CosmosSdkTx, StdFee, StdSignature } from "./types";
+export interface FeeTable {
+  readonly upload: StdFee;
+  readonly init: StdFee;
+  readonly exec: StdFee;
+  readonly send: StdFee;
+}
 export interface SigningCallback {
   (signBytes: Uint8Array): Promise<StdSignature>;
 }
@@ -28,10 +34,16 @@ export interface ExecuteResult {
   readonly logs: readonly Log[];
 }
 export declare class CosmWasmClient {
-  static makeReadOnly(url: string): CosmWasmClient;
-  static makeWritable(url: string, senderAddress: string, signCallback: SigningCallback): CosmWasmClient;
+  static makeReadOnly(url: string, feeTable?: Partial<FeeTable>): CosmWasmClient;
+  static makeWritable(
+    url: string,
+    senderAddress: string,
+    signCallback: SigningCallback,
+    feeTable?: Partial<FeeTable>,
+  ): CosmWasmClient;
   private readonly restClient;
   private readonly signingData;
+  private readonly feeTable;
   private get senderAddress();
   private get signCallback();
   private constructor();

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -83,7 +83,7 @@ export declare class CosmWasmClient {
     memo?: string,
     transferAmount?: readonly Coin[],
   ): Promise<ExecuteResult>;
-  sendToken(recipientAddress: string, transferAmount: readonly Coin[], memo?: string): Promise<ExecuteResult>;
+  sendToken(recipientAddress: string, transferAmount: readonly Coin[], memo?: string): Promise<PostTxResult>;
   /**
    * Returns the data at the key if present (raw contract dependent storage data)
    * or null if no data at this key.

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -83,7 +83,7 @@ export declare class CosmWasmClient {
     memo?: string,
     transferAmount?: readonly Coin[],
   ): Promise<ExecuteResult>;
-  sendToken(recipientAddress: string, transferAmount: readonly Coin[], memo?: string): Promise<PostTxResult>;
+  sendTokens(recipientAddress: string, transferAmount: readonly Coin[], memo?: string): Promise<PostTxResult>;
   /**
    * Returns the data at the key if present (raw contract dependent storage data)
    * or null if no data at this key.

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -34,7 +34,7 @@ export interface ExecuteResult {
   readonly logs: readonly Log[];
 }
 export declare class CosmWasmClient {
-  static makeReadOnly(url: string, feeTable?: Partial<FeeTable>): CosmWasmClient;
+  static makeReadOnly(url: string): CosmWasmClient;
   static makeWritable(
     url: string,
     senderAddress: string,
@@ -43,7 +43,7 @@ export declare class CosmWasmClient {
   ): CosmWasmClient;
   private readonly restClient;
   private readonly signingData;
-  private readonly feeTable;
+  private readonly fees;
   private get senderAddress();
   private get signCallback();
   private constructor();

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -83,6 +83,7 @@ export declare class CosmWasmClient {
     memo?: string,
     transferAmount?: readonly Coin[],
   ): Promise<ExecuteResult>;
+  sendToken(recipientAddress: string, transferAmount: readonly Coin[], memo?: string): Promise<ExecuteResult>;
   /**
    * Returns the data at the key if present (raw contract dependent storage data)
    * or null if no data at this key.


### PR DESCRIPTION
Based on #94 (merge that first)

This let's us easily make token transfers with this API, as we sometimes need to move some cash before we can call contracts.