### PR TITLE
Bump ts target to es2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es6",
-    "lib": ["es6"]
+    "target": "es2017",
+    "lib": ["es2017"]
   }
 }


### PR DESCRIPTION
This gives us smaller, faster and easier-to-read JS output, specially using native `async`/`await`.

Same as we did in IOV Core recently: https://github.com/iov-one/iov-core/pull/1386