### PR TITLE
Use wasmd v0.6.1 with rest server fixes

### DIFF
--- a/scripts/wasmd/env
+++ b/scripts/wasmd/env
@@ -1,5 +1,5 @@
 # Choose from https://hub.docker.com/r/cosmwasm/wasmd-demo/tags
 REPOSITORY="cosmwasm/wasmd-demo"
-VERSION="v0.6.0"
+VERSION="v0.6.1"
 
 CONTAINER_NAME="wasmd"


### PR DESCRIPTION
Not only for frontend testing (cors), but now enables min/max height queries (https://github.com/cosmwasm/wasmd/issues/73)