### PR TITLE
Add code and contract getters to CosmWasmClient

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,6 +7,9 @@ export { unmarshalTx } from "./decoding";
 export { makeSignBytes, marshalTx } from "./encoding";
 export { BroadcastMode, RestClient, TxsResponse } from "./restclient";
 export {
+  Code,
+  CodeDetails,
+  Contract,
   CosmWasmClient,
   GetNonceResult,
   PostTxResult,

--- a/packages/sdk/src/restclient.ts
+++ b/packages/sdk/src/restclient.ts
@@ -1,16 +1,7 @@
 import { Encoding } from "@iov/encoding";
 import axios, { AxiosError, AxiosInstance } from "axios";
 
-import {
-  CodeInfo,
-  ContractInfo,
-  CosmosSdkAccount,
-  CosmosSdkTx,
-  Model,
-  parseWasmData,
-  StdTx,
-  WasmData,
-} from "./types";
+import { CosmosSdkAccount, CosmosSdkTx, Model, parseWasmData, StdTx, WasmData } from "./types";
 
 const { fromBase64, toHex, toUtf8 } = Encoding;
 
@@ -129,6 +120,25 @@ export interface PostTxsResponse {
 interface EncodeTxResponse {
   // base64-encoded amino-binary encoded representation
   readonly tx: string;
+}
+
+export interface CodeInfo {
+  readonly id: number;
+  /** Bech32 account address */
+  readonly creator: string;
+  /** Hex-encoded sha256 hash of the code stored here */
+  readonly code_hash: string;
+  // TODO: these are not supported in current wasmd
+  readonly source?: string;
+  readonly builder?: string;
+}
+
+export interface ContractInfo {
+  readonly code_id: number;
+  /** Bech32 account address */
+  readonly creator: string;
+  /** Argument passed on initialization of the contract */
+  readonly init_msg: object;
 }
 
 interface GetCodeResult {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -160,30 +160,6 @@ export interface CosmosSdkAccount {
   readonly sequence: number;
 }
 
-export interface CodeInfo {
-  readonly id: number;
-  /** Bech32 account address */
-  readonly creator: string;
-  /** Hex-encoded sha256 hash of the code stored here */
-  readonly code_hash: string;
-  // TODO: these are not supported in current wasmd
-  readonly source?: string;
-  readonly builder?: string;
-}
-
-export interface CodeDetails {
-  // TODO: this should be base64 encoded string with content - not in current stack
-  readonly code: string;
-}
-
-export interface ContractInfo {
-  readonly code_id: number;
-  /** Bech32 account address */
-  readonly creator: string;
-  /** Argument passed on initialization of the contract */
-  readonly init_msg: object;
-}
-
 export interface WasmData {
   // key is hex-encoded
   readonly key: string;

--- a/packages/sdk/types/cosmwasmclient.d.ts
+++ b/packages/sdk/types/cosmwasmclient.d.ts
@@ -25,6 +25,26 @@ export interface SearchTxFilter {
   readonly minHeight?: number;
   readonly maxHeight?: number;
 }
+export interface Code {
+  readonly id: number;
+  /** Bech32 account address */
+  readonly creator: string;
+  /** Hex-encoded sha256 hash of the code stored here */
+  readonly checksum: string;
+  readonly source?: string;
+  readonly builder?: string;
+}
+export interface CodeDetails {
+  /** The original wasm bytes */
+  readonly wasm: Uint8Array;
+}
+export interface Contract {
+  readonly codeId: number;
+  /** Bech32 account address */
+  readonly creator: string;
+  /** Argument passed on initialization of the contract */
+  readonly initMsg: object;
+}
 export declare class CosmWasmClient {
   protected readonly restClient: RestClient;
   constructor(url: string, broadcastMode?: BroadcastMode);
@@ -50,6 +70,10 @@ export declare class CosmWasmClient {
   getBlock(height?: number): Promise<BlockResponse>;
   searchTx(query: SearchTxQuery, filter?: SearchTxFilter): Promise<readonly TxsResponse[]>;
   postTx(tx: StdTx): Promise<PostTxResult>;
+  getCodes(): Promise<readonly Code[]>;
+  getCodeDetails(codeId: number): Promise<CodeDetails>;
+  getContracts(codeId: number): Promise<readonly Contract[]>;
+  getContract(address: string): Promise<Contract>;
   /**
    * Returns the data at the key if present (raw contract dependent storage data)
    * or null if no data at this key.

--- a/packages/sdk/types/index.d.ts
+++ b/packages/sdk/types/index.d.ts
@@ -6,6 +6,9 @@ export { unmarshalTx } from "./decoding";
 export { makeSignBytes, marshalTx } from "./encoding";
 export { BroadcastMode, RestClient, TxsResponse } from "./restclient";
 export {
+  Code,
+  CodeDetails,
+  Contract,
   CosmWasmClient,
   GetNonceResult,
   PostTxResult,

--- a/packages/sdk/types/restclient.d.ts
+++ b/packages/sdk/types/restclient.d.ts
@@ -1,4 +1,4 @@
-import { CodeInfo, ContractInfo, CosmosSdkAccount, CosmosSdkTx, Model, StdTx } from "./types";
+import { CosmosSdkAccount, CosmosSdkTx, Model, StdTx } from "./types";
 interface NodeInfo {
   readonly network: string;
 }
@@ -91,6 +91,22 @@ export interface PostTxsResponse {
 }
 interface EncodeTxResponse {
   readonly tx: string;
+}
+export interface CodeInfo {
+  readonly id: number;
+  /** Bech32 account address */
+  readonly creator: string;
+  /** Hex-encoded sha256 hash of the code stored here */
+  readonly code_hash: string;
+  readonly source?: string;
+  readonly builder?: string;
+}
+export interface ContractInfo {
+  readonly code_id: number;
+  /** Bech32 account address */
+  readonly creator: string;
+  /** Argument passed on initialization of the contract */
+  readonly init_msg: object;
 }
 interface GetCodeResult {
   readonly code: string;

--- a/packages/sdk/types/types.d.ts
+++ b/packages/sdk/types/types.d.ts
@@ -116,25 +116,6 @@ export interface CosmosSdkAccount {
   readonly account_number: number;
   readonly sequence: number;
 }
-export interface CodeInfo {
-  readonly id: number;
-  /** Bech32 account address */
-  readonly creator: string;
-  /** Hex-encoded sha256 hash of the code stored here */
-  readonly code_hash: string;
-  readonly source?: string;
-  readonly builder?: string;
-}
-export interface CodeDetails {
-  readonly code: string;
-}
-export interface ContractInfo {
-  readonly code_id: number;
-  /** Bech32 account address */
-  readonly creator: string;
-  /** Argument passed on initialization of the contract */
-  readonly init_msg: object;
-}
 export interface WasmData {
   readonly key: string;
   readonly val: string;


### PR DESCRIPTION
This is an alternative to #112, with some differences:
* use our own types `Code`, `CodeDetails`, `Contract` exposed from @cosmwasm/sdk that don't need to match the REST response directly
* Prepare for https://github.com/cosmwasm/wasmd/issues/75, avoiding the `/wasm/contract` getter, which has no long term usage
* Try to come up with the best possible names instead of mirroring REST backend or client names