### PR TITLE
Updates for wasmd v0.7.0-rc2

### DIFF
--- a/packages/sdk/src/restclient.ts
+++ b/packages/sdk/src/restclient.ts
@@ -168,7 +168,7 @@ type RestClientResponse =
   | WasmResponse<string>
   | WasmResponse<CodeInfo[]>
   | WasmResponse<ContractInfo[] | null>
-  | WasmResponse<ContractDetails>
+  | WasmResponse<ContractDetails | null>
   | WasmResponse<GetCodeResult>;
 
 /**
@@ -363,21 +363,8 @@ export class RestClient {
    */
   public async getContractInfo(address: string): Promise<ContractDetails | null> {
     const path = `/wasm/contract/${address}`;
-
-    try {
-      const response = (await this.get(path)) as WasmResponse<ContractDetails>;
-      return unwrapWasmResponse(response);
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.startsWith("unknown address:")) {
-          return null;
-        } else {
-          throw error;
-        }
-      } else {
-        throw error;
-      }
-    }
+    const response = (await this.get(path)) as WasmResponse<ContractDetails | null>;
+    return unwrapWasmResponse(response);
   }
 
   // Returns all contract state.

--- a/packages/sdk/types/restclient.d.ts
+++ b/packages/sdk/types/restclient.d.ts
@@ -126,7 +126,7 @@ declare type RestClientResponse =
   | WasmResponse<string>
   | WasmResponse<CodeInfo[]>
   | WasmResponse<ContractInfo[] | null>
-  | WasmResponse<ContractDetails>
+  | WasmResponse<ContractDetails | null>
   | WasmResponse<GetCodeResult>;
 /**
  * The mode used to send transaction

--- a/scripts/wasmd/env
+++ b/scripts/wasmd/env
@@ -1,5 +1,5 @@
 # Choose from https://hub.docker.com/r/cosmwasm/wasmd-demo/tags
 REPOSITORY="cosmwasm/wasmd-demo"
-VERSION="v0.7.0-rc1"
+VERSION="v0.7.0-rc2"
 
 CONTAINER_NAME="wasmd"


### PR DESCRIPTION
Query getContract now returns null (no error) when no such contract. Simplify js error handling code.
