### PR TITLE
Add and test isValidBuilder

### DIFF
--- a/packages/sdk/src/builder.spec.ts
+++ b/packages/sdk/src/builder.spec.ts
@@ -1,0 +1,64 @@
+import { isValidBuilder } from "./builder";
+
+describe("builder", () => {
+  describe("isValidBuilder", () => {
+    // Valid cases
+
+    it("returns true for simple examples", () => {
+      expect(isValidBuilder("myorg/super-optimizer:0.1.2")).toEqual(true);
+      expect(isValidBuilder("myorg/super-optimizer:42")).toEqual(true);
+    });
+
+    it("supports images with no organization", () => {
+      // from https://hub.docker.com/_/ubuntu
+      expect(isValidBuilder("ubuntu:xenial-20200212")).toEqual(true);
+      // from https://hub.docker.com/_/rust
+      expect(isValidBuilder("rust:1.40.0")).toEqual(true);
+    });
+
+    it("supports images with multi level names", () => {
+      expect(isValidBuilder("myorg/department-x/office-y/technology-z/super-optimizer:0.1.2")).toEqual(true);
+    });
+
+    it("returns true for tags with lower and upper chars", () => {
+      expect(isValidBuilder("myorg/super-optimizer:0.1.2-alpha")).toEqual(true);
+      expect(isValidBuilder("myorg/super-optimizer:0.1.2-Alpha")).toEqual(true);
+    });
+
+    it("allows very long images", () => {
+      // This is > 2 KiB of data
+      expect(
+        isValidBuilder(
+          "myorgisnicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenice/super-optimizer:42",
+        ),
+      ).toEqual(true);
+    });
+
+    // Invalid cases
+
+    it("returns false for missing or empty tag", () => {
+      expect(isValidBuilder("myorg/super-optimizer")).toEqual(false);
+      expect(isValidBuilder("myorg/super-optimizer:")).toEqual(false);
+    });
+
+    it("returns false for name components starting or ending with a separator", () => {
+      expect(isValidBuilder(".myorg/super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("-myorg/super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("_myorg/super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("myorg./super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("myorg-/super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("myorg_/super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("myorg/.super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("myorg/-super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("myorg/_super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("myorg/super-optimizer.:42")).toEqual(false);
+      expect(isValidBuilder("myorg/super-optimizer-:42")).toEqual(false);
+      expect(isValidBuilder("myorg/super-optimizer_:42")).toEqual(false);
+    });
+
+    it("returns false for upper case character in name component", () => {
+      expect(isValidBuilder("mYorg/super-optimizer:42")).toEqual(false);
+      expect(isValidBuilder("myorg/super-Optimizer:42")).toEqual(false);
+    });
+  });
+});

--- a/packages/sdk/src/builder.spec.ts
+++ b/packages/sdk/src/builder.spec.ts
@@ -9,13 +9,6 @@ describe("builder", () => {
       expect(isValidBuilder("myorg/super-optimizer:42")).toEqual(true);
     });
 
-    it("supports images with no organization", () => {
-      // from https://hub.docker.com/_/ubuntu
-      expect(isValidBuilder("ubuntu:xenial-20200212")).toEqual(true);
-      // from https://hub.docker.com/_/rust
-      expect(isValidBuilder("rust:1.40.0")).toEqual(true);
-    });
-
     it("supports images with multi level names", () => {
       expect(isValidBuilder("myorg/department-x/office-y/technology-z/super-optimizer:0.1.2")).toEqual(true);
     });
@@ -23,15 +16,6 @@ describe("builder", () => {
     it("returns true for tags with lower and upper chars", () => {
       expect(isValidBuilder("myorg/super-optimizer:0.1.2-alpha")).toEqual(true);
       expect(isValidBuilder("myorg/super-optimizer:0.1.2-Alpha")).toEqual(true);
-    });
-
-    it("allows very long images", () => {
-      // This is > 2 KiB of data
-      expect(
-        isValidBuilder(
-          "myorgisnicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenice/super-optimizer:42",
-        ),
-      ).toEqual(true);
     });
 
     // Invalid cases
@@ -59,6 +43,21 @@ describe("builder", () => {
     it("returns false for upper case character in name component", () => {
       expect(isValidBuilder("mYorg/super-optimizer:42")).toEqual(false);
       expect(isValidBuilder("myorg/super-Optimizer:42")).toEqual(false);
+    });
+
+    it("returns false for long images", () => {
+      expect(
+        isValidBuilder(
+          "myorgisnicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenicenice/super-optimizer:42",
+        ),
+      ).toEqual(false);
+    });
+
+    it("returns false for images with no organization", () => {
+      // Those are valid dockerhub images from https://hub.docker.com/_/ubuntu and https://hub.docker.com/_/rust
+      // but not valid in the context of CosmWasm Verify
+      expect(isValidBuilder("ubuntu:xenial-20200212")).toEqual(false);
+      expect(isValidBuilder("rust:1.40.0")).toEqual(false);
     });
   });
 });

--- a/packages/sdk/src/builder.ts
+++ b/packages/sdk/src/builder.ts
@@ -8,9 +8,13 @@
 // A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes.
 // A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
 const dockerImagePattern = new RegExp(
-  "^[a-z0-9][a-z0-9._-]*[a-z0-9](/[a-z0-9][a-z0-9._-]*[a-z0-9])*:[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$",
+  "^[a-z0-9][a-z0-9._-]*[a-z0-9](/[a-z0-9][a-z0-9._-]*[a-z0-9])+:[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$",
 );
 
+/** Max length in bytes/characters (regexp enforces all ASCII, even if that is not required by the standard) */
+const builderMaxLength = 128;
+
 export function isValidBuilder(builder: string): boolean {
+  if (builder.length > builderMaxLength) return false;
   return !!builder.match(dockerImagePattern);
 }

--- a/packages/sdk/src/builder.ts
+++ b/packages/sdk/src/builder.ts
@@ -1,0 +1,16 @@
+// A docker image regexp. We remove support for non-standard registries for simplicity.
+// https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+//
+// An image name is made up of slash-separated name components (optionally prefixed by a registry hostname).
+// Name components may contain lowercase characters, digits and separators.
+// A separator is defined as a period, one or two underscores, or one or more dashes. A name component may not start or end with a separator.
+//
+// A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes.
+// A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+const dockerImagePattern = new RegExp(
+  "^[a-z0-9][a-z0-9._-]*[a-z0-9](/[a-z0-9][a-z0-9._-]*[a-z0-9])*:[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$",
+);
+
+export function isValidBuilder(builder: string): boolean {
+  return !!builder.match(dockerImagePattern);
+}

--- a/packages/sdk/types/builder.d.ts
+++ b/packages/sdk/types/builder.d.ts
@@ -1,0 +1,1 @@
+export declare function isValidBuilder(builder: string): boolean;


### PR DESCRIPTION
This is the same regexp as in wasmd. `isValidBuilder` is unsed for now but could be used to prevent signing broken data.

Two things I noted here:
1. The regexp itself does not have a length limit. We should add have a limit independent of this.
2. Names without origanizations are supported. My gut feeling is that non of our wools will get a `_` organization on dockerhub and we should disallow those to prevent plain `cosmwasm-opt:0.6.2` from working