### PR TITLE
Fix fast-deep-equal dependency

### DIFF
--- a/packages/faucet/package.json
+++ b/packages/faucet/package.json
@@ -43,7 +43,6 @@
     "@iov/utils": "^2.0.2",
     "@koa/cors": "^3.0.0",
     "axios": "^0.19.0",
-    "fast-deep-equal": "^3.1.1",
     "koa": "^2.11.0",
     "koa-bodyparser": "^4.2.1",
     "readonly-date": "^1.0.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,6 +42,7 @@
     "@iov/encoding": "^2.1.0",
     "@iov/utils": "^2.0.2",
     "axios": "^0.19.0",
+    "fast-deep-equal": "^3.1.1",
     "pako": "^1.0.11"
   },
   "devDependencies": {


### PR DESCRIPTION
Required for running `npx @cosmwasm/cli`